### PR TITLE
Update package script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ngrok": "ngrok http 8081",
     "update:url": "node devUtils/updateDashboard.mjs",
     "shopify": "shopify",
-    "s:e:create": "shopify app scaffold extension",
+    "s:e:create": "shopify app generate extension",
     "s:e:deploy": "shopify app deploy"
   },
   "dependencies": {


### PR DESCRIPTION
scaffold  to generate 

`The command scaffold has been deprecated in favor of generate and will be eventually deleted. You might need to update the scaffold script in the project's package.json.
 `

ref : https://shopify.dev/apps/tools/cli/commands#generate-extension