### PR TITLE
Fix typo on isShopActive middleware

### DIFF
--- a/server/middleware/isShopActive.js
+++ b/server/middleware/isShopActive.js
@@ -8,12 +8,12 @@ const isShopActive = async (req, res, next) => {
     return;
   }
 
-  const isShopAvaialble = await StoreModel.findOne({ shop });
+  const isShopAvailable = await StoreModel.findOne({ shop });
 
-  if (isShopAvaialble === null || !isShopAvaialble.isActive) {
-    if (isShopAvaialble === null) {
+  if (isShopAvailable === null || !isShopAvailable.isActive) {
+    if (isShopAvailable === null) {
       await StoreModel.create({ shop, isActive: false });
-    } else if (!isShopAvaialble.isActive) {
+    } else if (!isShopAvailable.isActive) {
       await StoreModel.findOneAndUpdate({ shop }, { isActive: false });
     }
     res.redirect(`/auth?shop=${shop}&host=${host}`);


### PR DESCRIPTION
`isShopActive` middleware had a variable named `isShopAvaialble` which consists of a typo. We have fixed that. Thank you.