### PR TITLE
added shopify missing scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "-----> Shopify <-----": "",
     "g:install": "npm i -g @shopify/app@latest @shopify/cli@latest",
     "shopify": "shopify",
+    "s:e:create": "shopify app scaffold extension",
+    "s:e:deploy": "shopify app deploy",
     "-----> Reserved Scripts <-----": "",
     "preserve": "npm run build"
   },


### PR DESCRIPTION
thisi two scripts were mentioned in docs but not present in the package json 

```JSON
 "s:e:create": "shopify app scaffold extension",
 "s:e:deploy": "shopify app deploy"
```